### PR TITLE
more checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = function(source) {
                 node.type === 'CallExpression' &&
                 node.callee.type === 'Identifier' &&
                 node.callee.name === 'require' &&
+                node.arguments[0] && node.arguments[0].value &&
                 node.arguments[0].value.match(/^(b|e|m)\:/)
             ) {
                 let requireIdx = null;
@@ -72,10 +73,8 @@ module.exports = function(source) {
                             return res.concat(entity.requires);
                         }, []);
 
-                        node.update(
-                            `[${requires.join(',')}]` +
-                            (requireIdx !== null? `[${requireIdx}].default.applyDecls()` : '')
-                        );
+                        const n = `[${requires.join(',')}]` + (requireIdx !== null? `[${requireIdx}]` : '');
+                        node.update((n && requireIdx !== null) ? `(${n}.default ? ${n}.default.applyDecls() : ${n}.applyDecls())` : n);
                     }));
             }
         });

--- a/index.js
+++ b/index.js
@@ -73,8 +73,15 @@ module.exports = function(source) {
                             return res.concat(entity.requires);
                         }, []);
 
-                        const n = `[${requires.join(',')}]` + (requireIdx !== null? `[${requireIdx}]` : '');
-                        node.update((n && requireIdx !== null) ? `(${n}.default ? ${n}.default.applyDecls() : ${n}.applyDecls())` : n);
+
+                        const idx = requireIdx !== null;
+                            n = `[${requires.join(',')}]${idx? `[${requireIdx}]` : ''}`;
+
+                        node.update(idx? `
+                          (${n}.default?
+                              ${n}.default.applyDecls() :
+                              ${n}.applyDecls())
+                          ` : n);
                     }));
             }
         });

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = function(source) {
                         }, []);
 
 
-                        const idx = requireIdx !== null;
+                        const idx = requireIdx !== null,
                             n = `[${requires.join(',')}]${idx? `[${requireIdx}]` : ''}`;
 
                         node.update(idx? `
@@ -120,7 +120,9 @@ function parseEntityImport(entityImport, ctx) {
                     modName = splitMod[0],
                     modVals = splitMod[1];
 
-                main.elem || (main.elem = ctx.elem);
+                if(main.block === ctx.block) {
+                    main.elem || (main.elem = ctx.elem);
+                }
 
                 if(modVals) {
                     modVals.split('|').forEach(modVal => {


### PR DESCRIPTION
It needs for cases like this:

``` js
export default require(`../${process.env.NODE_ENV}`);
```

Also, it should work with required modules. Look to this issue https://github.com/babel/babel/issues/2212. Many users use the plugin for babel https://github.com/59naga/babel-plugin-add-module-exports. It fixes some shit for right work.
