### PR TITLE
Fix sourceType of parsed files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(source) {
 
     generators.i18n = require('./generators/i18n').generate(langs);
 
-    const result = falafel(source, node => {
+    const result = falafel(source, { sourceType: 'module' }, node => {
         // match `require('b:button')`
         if(!(
             node.type === 'CallExpression' &&


### PR DESCRIPTION
 webpack2 could work with es6 modules, so we have to parse files with `imports/exports` inside.

fix: https://github.com/bem-site/bem-forum-content-ru/issues/1425