### PR TITLE
webpack 4 support; coding without semicolons

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(source) {
     this.cacheable && this.cacheable();
 
     const callback = this.async(),
-        options = Object.assign({}, this.options.bemLoader, loaderUtils.getOptions(this)),
+        options = Object.assign({}, (this.options && this.options.bemLoader || {}), loaderUtils.getOptions(this)),
         levelsMap = options.levels || bemConfig.levelMapSync(),
         levels = Array.isArray(levelsMap) ? levelsMap : Object.keys(levelsMap),
         techs = options.techs || ['js'],

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ module.exports = function(source) {
                             return `${(generators[tech] || generators['*'])(extToFiles[ext])}`;
                         });
 
-                    node.update(`[${res.join(',')}][0]`);
+                    node.update(`;[${res.join(',')}][0]`);
                 })
         );
     });


### PR DESCRIPTION
1) webpack 4 removes this.options
2) bug without semicolons