### PR TITLE
Pass inputSourceMap to the next loader in chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const path = require('path'),
     loaderUtils = require('loader-utils'),
     getGenerators = require('./generators');
 
-module.exports = function(source) {
+module.exports = function(source, inputSourceMap) {
     this.cacheable && this.cacheable();
 
     const callback = this.async(),
@@ -159,6 +159,6 @@ module.exports = function(source) {
     });
 
     Promise.all(allPromises)
-        .then(() => callback(null, result.toString()))
+        .then(() => callback(null, result.toString(), inputSourceMap))
         .catch(callback);
 };


### PR DESCRIPTION
In webpack3 this means that we'll be able to see original sources
referenced by source maps, not the files transpiled by
webpack-bem-loader.