### PR TITLE
Support dynamic import() syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,12 @@ const path = require('path'),
     bemConfig = require('bem-config')(),
     requiredPath = require('required-path'),
     falafel = require('falafel'),
+    acorn = require('acorn'),
+    injectDynamicImportSupport = require('acorn-dynamic-import/lib/inject').default,
     loaderUtils = require('loader-utils'),
     getGenerators = require('./generators');
+
+injectDynamicImportSupport(acorn);
 
 module.exports = function(source, inputSourceMap) {
     this.cacheable && this.cacheable();
@@ -44,7 +48,15 @@ module.exports = function(source, inputSourceMap) {
 
     generators.i18n = require('./generators/i18n').generate(langs);
 
-    const result = falafel(source, { ecmaVersion : 8, sourceType : 'module' }, node => {
+    const falafelOptions = {
+        ecmaVersion : 8,
+        sourceType : 'module',
+        parser : acorn,
+        plugins : {
+            dynamicImport : true
+        }
+    };
+    const result = falafel(source, falafelOptions, node => {
         // match `require('b:button')`
         if(!(
             node.type === 'CallExpression' &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,25 +220,16 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
+      "version": "5.5.3",
+      "resolved": "https://artifactory.dev.bi.zone:8443/repository/npm/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
     "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://artifactory.dev.bi.zone:8443/repository/npm/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
+        "acorn": "5.5.3"
       }
     },
     "acorn-globals": {
@@ -247,7 +238,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2"
+        "acorn": "5.5.3"
       }
     },
     "acorn-jsx": {
@@ -1943,7 +1934,7 @@
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -2149,7 +2140,7 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.5.3",
         "foreach": "2.0.5",
         "isarray": "0.0.1",
         "object-keys": "1.0.11"
@@ -7780,7 +7771,7 @@
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "6.1.1",
         "ajv-keywords": "3.1.0",
@@ -7804,6 +7795,23 @@
         "yargs": "8.0.2"
       },
       "dependencies": {
+        "acorn-dynamic-import": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.dev.bi.zone:8443/repository/npm/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+          "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+          "dev": true,
+          "requires": {
+            "acorn": "4.0.13"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "resolved": "https://artifactory.dev.bi.zone:8443/repository/npm/acorn/-/acorn-4.0.13.tgz",
+              "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+              "dev": true
+            }
+          }
+        },
         "ajv": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@bem/fs-scheme": "2.1.0",
     "@bem/import-notation": "1.1.3",
     "@bem/naming": "2.0.0-6",
+    "acorn": "5.5.3",
+    "acorn-dynamic-import": "3.0.0",
     "bem-config": "3.2.3",
     "falafel": "2.1.0",
     "loader-utils": "1.1.0",

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,0 +1,22 @@
+const webpack = require('./helpers/compiler');
+
+describe('Parser', () => {
+    test('dynamic import()', async () => {
+        const mock = {
+            'index.js' : `const test = import('./module.js')`,
+            'module.js' : 'export null'
+        };
+        const config = {
+            loader : {
+                options : {
+                    levels : []
+                }
+            }
+        };
+
+        const { stats } = await webpack('index.js', { config, mock });
+        const { source } = stats.toJson().modules[0];
+
+        expect(source).toBe(mock['index.js']);
+    });
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -4,7 +4,7 @@ describe('Parser', () => {
     test('dynamic import()', async () => {
         const mock = {
             'index.js' : `const test = import('./module.js')`,
-            'module.js' : 'export null'
+            'module.js' : 'export default null'
         };
         const config = {
             loader : {


### PR DESCRIPTION
While acorn itself [won't support](https://github.com/acornjs/acorn/issues/477) `import()` spec until it hasn't reached stage 4, in some cases it's rather painful not to be able to use this syntax in the same file with bem imports. Fortunately, falafel supports custom parser and we could manually use acorn with extended syntax support.
