### PR TITLE
Do not throw on Webpack v4

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = function(source, inputSourceMap) {
     this.cacheable && this.cacheable();
 
     const callback = this.async(),
-        options = Object.assign({}, this.options.bemLoader, loaderUtils.getOptions(this)),
+        optionsFromCompiler = this.options && this.options.bemLoader,
+        options = Object.assign({}, optionsFromCompiler, loaderUtils.getOptions(this)),
         levelsMap = options.levels || bemConfig.levelMapSync(),
         levels = Array.isArray(levelsMap) ? levelsMap : Object.keys(levelsMap),
         techs = options.techs || ['js'],


### PR DESCRIPTION
Property `this.options` has been deprecated since webpack 3. In webpack 4 it's removed completely. To support both the new version and the old ones simple check added.