### PR TITLE
Remove get bemLoader option from global config of webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(source, inputSourceMap) {
     this.cacheable && this.cacheable();
 
     const callback = this.async(),
-        options = Object.assign({}, this.options.bemLoader, loaderUtils.getOptions(this)),
+        options = Object.assign({}, loaderUtils.getOptions(this)),
         levelsMap = options.levels || bemConfig.levelMapSync(),
         levels = Array.isArray(levelsMap) ? levelsMap : Object.keys(levelsMap),
         techs = options.techs || ['js'],


### PR DESCRIPTION
Removed option "bemLoader" from global config for compatibility with webpack 4+